### PR TITLE
fix: changed sprintf to safer function of snprintf

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -163,8 +163,9 @@ static void init_dri_cards()
 			card->pci_address = malloc(strlen(entry->d_name) + 1);
 
 			extract_pci_address(card->pci_address, entry->d_name);
-			sprintf(card->devtmpfs_path, "%s/%s", DRI_PATH,
-				entry->d_name);
+			snprintf(card->devtmpfs_path,
+				 sizeof(card->devtmpfs_path), "%s/%s", DRI_PATH,
+				 entry->d_name);
 
 			list_add_tail(&card->list, &dri_cards_list);
 		}


### PR DESCRIPTION
I haven't verified if this causes an actual issue, but the use of sprintf here may be unsafe because it writes to a fixed-size buffer on the heap, potentially causing a heap buffer overflow. To mitigate this risk, I replaced it with snprintf, which is safer as it checks the buffer boundaries.